### PR TITLE
Add news item to web site for decadal whitepaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # cosmic-explorer.github.io
-Cosmic Explorer web page
+This repository hosts the Cosmic Explorer project's web page, available at https://cosmicexplorer.org.
+

--- a/index.html
+++ b/index.html
@@ -405,6 +405,22 @@ and even a stochastic gravitational-wave background!
                           </h6>
                         </a>
                         <h4 class="mb-3">
+                         <strong>Cosmic Explorer White Paper for Astro2020 Decadal Survey Submitted</strong>
+                        </h4>
+
+                        <p>Together with members of the LIGO lab, the
+   Cosmic Explorer team wrote and submitted “Cosmic Explorer: The
+   U.S. Contribution to Gravitational-Wave Astronomy beyond LIGO,” an
+   Astro2020 Decadal Survey APC ground-based technology development
+   white paper. The white paper is available online
+   at <a href="https://arxiv.org/abs/1907.04833">https://arxiv.org/abs/1907.04833</a>.</p>
+                        <p>by
+                            <a>
+                                <strong>Geoffrey Lovelace</strong>
+                            </a>on August 5, 2019</p>
+                        <a href="https://arxiv.org/abs/1907.04833" class="btn btn-primary btn-md">Read more</a>
+			<br><br>
+                        <h4 class="mb-3">
                          <strong>US 3G Effort Funded by NSF</strong>
                         </h4>
 
@@ -420,7 +436,7 @@ and even a stochastic gravitational-wave background!
                         <p>by
                             <a>
                                 <strong>Matthew Evans</strong>
-                            </a>, 13 August 2018</p>
+                            </a>on August 13, 2018</p>
                         <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1836814" class="btn btn-primary btn-md">Read more</a>
 
                     </div>
@@ -554,7 +570,7 @@ The Cosmic Explorer artwork was created by Evan Hall and shows the large L-shape
 
         <!--Copyright-->
         <div class="footer-copyright py-3 text-center">
-            © 2018 Copyright: Matthew Evans
+            © 2019 Copyright: Cosmic Explorer Project
         </div>
         <!--/.Copyright-->
 


### PR DESCRIPTION
This update to the website adds a news item for the decadal white paper and changes the copyright to "Cosmic Explorer Project".